### PR TITLE
Override default reload_connections to false

### DIFF
--- a/lib/fluent/plugin/out_aws-elasticsearch-service.rb
+++ b/lib/fluent/plugin/out_aws-elasticsearch-service.rb
@@ -20,6 +20,12 @@ module Fluent
       config_param :assume_role_session_name, :string, :default => "fluentd"
     end
 
+    # here overrides default value of reload_connections to false because
+    # AWS Elasticsearch Service doesn't return addresses of nodes and Elasticsearch client
+    # fails to reload connections properly. This ends up "temporarily failed to flush the buffer"
+    # error repeating forever. See this discussion for details:
+    # https://discuss.elastic.co/t/elasitcsearch-ruby-raises-cannot-get-new-connection-from-pool-error/36252
+    config_set_default :reload_connections, false
 
     #
     # @override


### PR DESCRIPTION
I'm getting some inquiries about failure of fluentd. They use fluent-plugin-aws-elasticsearch-service with relatively short flush_interval and occasionally (every once a week, etc.), fluentd stops flushing data to Elasticsearch until they restart fluentd.

According to some articles I found, combination of elasticsearch-ruby and AWS Elasticsearch Service has a problem:

* http://blog.jicoman.info/2016/01/fluentd_amazon_es/
* https://retrorocket.biz/archives/334
* https://discuss.elastic.co/t/elasitcsearch-ruby-raises-cannot-get-new-connection-from-pool-error/36252/11

This PR overrides default value of `reload_connections` to `false` as a workaround to avoid the issue.
