### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in fluent-plugin-aws-elasticsearch-service.gemspec
 gemspec
 
-gem 'fluent-plugin-elasticsearch', '~> 1.0', require: false
+gem 'fluent-plugin-elasticsearch', "~> 2.0.0.rc.1", require: false
 gem 'aws-sdk', '~> 2', require: false
 gem 'faraday_middleware-aws-signers-v4', '>= 0.1.0', '< 0.1.2', require: false

--- a/fluent-plugin-aws-elasticsearch-service.gemspec
+++ b/fluent-plugin-aws-elasticsearch-service.gemspec
@@ -23,8 +23,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "test-unit", "~> 3.0"
   spec.add_runtime_dependency "fluentd", "~> 0"
-  spec.add_runtime_dependency "fluent-plugin-elasticsearch", "~> 1.0"
+  spec.add_runtime_dependency "fluent-plugin-elasticsearch", "~> 2.0.0.rc.1"
   spec.add_runtime_dependency "aws-sdk", "~> 2"
   spec.add_runtime_dependency "faraday_middleware-aws-signers-v4", ">= 0.1.0", "< 0.1.2"
 end

--- a/lib/fluent/plugin/out_aws-elasticsearch-service.rb
+++ b/lib/fluent/plugin/out_aws-elasticsearch-service.rb
@@ -6,10 +6,10 @@ require 'aws-sdk'
 require 'faraday_middleware/aws_signers_v4'
 
 
-module Fluent
+module Fluent::Plugin
   class AwsElasticsearchServiceOutput < ElasticsearchOutput
 
-    Plugin.register_output('aws-elasticsearch-service', self)
+    Fluent::Plugin.register_output('aws-elasticsearch-service', self)
 
     config_section :endpoint do
       config_param :region, :string
@@ -48,6 +48,10 @@ module Fluent
       {
         hosts: hosts
       }
+    end
+
+    def write(chunk)
+      super
     end
 
 

--- a/spec/lib/fluent/plugin/out_aws-elasticsearch-service_spec.rb
+++ b/spec/lib/fluent/plugin/out_aws-elasticsearch-service_spec.rb
@@ -1,28 +1,39 @@
 # -*- encoding: utf-8 -*-
+require 'spec_helper'
 
-describe Fluent::AwsElasticsearchServiceOutput do
-  let(:driver)   { Fluent::Test::OutputTestDriver.new(Fluent::AwsElasticsearchServiceOutput, 'test.metrics').configure(config) }
+describe Fluent::Plugin::AwsElasticsearchServiceOutput do
+  let(:driver)   { Fluent::Test::Driver::Output.new(Fluent::Plugin::AwsElasticsearchServiceOutput).configure(config) }
   let(:instance) { driver.instance }
 
   describe "config" do
     let(:config) do
       %[
       <endpoint>
+        region us-east-1
         url  xxxxxxxxxxxxxxxxxxxx
       </endpoint>
       ]
     end
 
     it "`endpoint` is array." do
-      expect( instance.endpoint ).to eq "xxxxxxxxxxxxxxxxxxxx"
+      instance.instance_variable_get(:@endpoint).map do |ep|
+        expect(ep[:url]).to eq "xxxxxxxxxxxxxxxxxxxx"
+      end
     end
 
-    it "should get room_id" do
-      expect( instance.room_id ).to eq "1234567890"
+    it "should get region" do
+      instance.instance_variable_get(:@endpoint).map do |ep|
+        expect(ep[:region]).to eq "us-east-1"
+      end
     end
 
-    it "should get body" do
-      expect( instance.body ).to eq "some message"
+    it "should get default values" do
+      instance.instance_variable_get(:@endpoint).map do |ep|
+        expect(ep[:access_key_id]).to eq ""
+        expect(ep[:secret_access_key]).to eq ""
+        expect(ep[:assume_role_arn]).to eq nil
+        expect(ep[:assume_role_session_name]).to eq "fluentd"
+      end
     end
   end
 end

--- a/spec/lib/fluent/plugin/out_aws-elasticsearch-service_spec.rb
+++ b/spec/lib/fluent/plugin/out_aws-elasticsearch-service_spec.rb
@@ -16,19 +16,19 @@ describe Fluent::Plugin::AwsElasticsearchServiceOutput do
     end
 
     it "`endpoint` is array." do
-      instance.instance_variable_get(:@endpoint).map do |ep|
+      instance.endpoint.map do |ep|
         expect(ep[:url]).to eq "xxxxxxxxxxxxxxxxxxxx"
       end
     end
 
     it "should get region" do
-      instance.instance_variable_get(:@endpoint).map do |ep|
+      instance.endpoint.map do |ep|
         expect(ep[:region]).to eq "us-east-1"
       end
     end
 
     it "should get default values" do
-      instance.instance_variable_get(:@endpoint).map do |ep|
+      instance.endpoint.map do |ep|
         expect(ep[:access_key_id]).to eq ""
         expect(ep[:secret_access_key]).to eq ""
         expect(ep[:assume_role_arn]).to eq nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'fluent/load'
 require 'fluent/test'
+require 'fluent/test/driver/output'
 
 require 'fluent/plugin/out_aws-elasticsearch-service'
 


### PR DESCRIPTION
I've tried to migrate to use v0.14 Output Plugin API.
This PR contains major update change.
Could you bump up major version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks in advance.