### PR TITLE
Update fluent-plugin-elasticsearch version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in fluent-plugin-aws-elasticsearch-service.gemspec
 gemspec
 
-gem 'fluent-plugin-elasticsearch', "~> 2.0.0.rc.1", require: false
+gem 'fluent-plugin-elasticsearch', "~> 2.0.0", require: false
 gem 'aws-sdk', '~> 2', require: false
 gem 'faraday_middleware-aws-signers-v4', '>= 0.1.0', '< 0.1.2', require: false

--- a/fluent-plugin-aws-elasticsearch-service.gemspec
+++ b/fluent-plugin-aws-elasticsearch-service.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "test-unit", "~> 3.0"
   spec.add_runtime_dependency "fluentd", "~> 0"
-  spec.add_runtime_dependency "fluent-plugin-elasticsearch", "~> 2.0.0.rc.1"
+  spec.add_runtime_dependency "fluent-plugin-elasticsearch", "~> 2.0.0"
   spec.add_runtime_dependency "aws-sdk", "~> 2"
   spec.add_runtime_dependency "faraday_middleware-aws-signers-v4", ">= 0.1.0", "< 0.1.2"
 end


### PR DESCRIPTION
2.0.0 has now been released so we shouldn't use the RC version.

cc @cosmo0920 