### PR TITLE
upgrade to aws-sdk-v3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'fluent-plugin-elasticsearch', "~> 2.0.0.rc.1", require: false
-gem 'aws-sdk', '~> 2', require: false
-gem 'faraday_middleware-aws-signers-v4', '>= 0.1.0', '< 0.1.2', require: false
+gem 'aws-sdk-elasticsearchservice', '~> 1', require: false
+gem 'faraday_middleware-aws-sigv4', "~> 0.2.4", require: false

--- a/fluent-plugin-aws-elasticsearch-service.gemspec
+++ b/fluent-plugin-aws-elasticsearch-service.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "test-unit", "~> 3.0"
   spec.add_runtime_dependency "fluentd", "~> 0"
   spec.add_runtime_dependency "fluent-plugin-elasticsearch", "~> 2.0.0.rc.1"
-  spec.add_runtime_dependency "aws-sdk", "~> 2"
-  spec.add_runtime_dependency "faraday_middleware-aws-signers-v4", ">= 0.1.0", "< 0.1.2"
+  spec.add_runtime_dependency "aws-sdk-elasticsearchservice", "~> 1"
+  spec.add_runtime_dependency "faraday_middleware-aws-sigv4", "~> 0.2.4"
 end

--- a/lib/fluent/plugin/out_aws-elasticsearch-service.rb
+++ b/lib/fluent/plugin/out_aws-elasticsearch-service.rb
@@ -2,8 +2,8 @@
 
 require 'rubygems'
 require 'fluent/plugin/out_elasticsearch'
-require 'aws-sdk'
-require 'faraday_middleware/aws_signers_v4'
+require 'aws-sdk-elasticsearchservice'
+require 'faraday_middleware/aws_sigv4'
 
 
 module Fluent::Plugin


### PR DESCRIPTION
close #33

- [faraday_middleware-aws-signers-v4](https://github.com/winebarrel/faraday_middleware-aws-signers-v4) is moved to [araday_middleware-aws-sigv4](https://github.com/winebarrel/faraday_middleware-aws-sigv4)
- we can use [aws-sdk-elasticsearchservice](https://rubygems.org/gems/aws-sdk-elasticsearchservice/) for aws-sdk-v3

----

sorry I'm not familier with ruby and fluent plugin, if something wrong let me know 🙇 