### PR TITLE
add fluentd version 1 to supported dependencies

### DIFF
--- a/fluent-plugin-aws-elasticsearch-service.gemspec
+++ b/fluent-plugin-aws-elasticsearch-service.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "test-unit", "~> 3.0"
-  spec.add_runtime_dependency "fluentd", "< 2"
+  spec.add_runtime_dependency "fluentd"
   spec.add_runtime_dependency "fluent-plugin-elasticsearch", "~> 2.4.0"
   spec.add_runtime_dependency "aws-sdk", "~> 3"
   spec.add_runtime_dependency "faraday_middleware-aws-sigv4", ">= 0.2.4", "< 0.3.0"

--- a/fluent-plugin-aws-elasticsearch-service.gemspec
+++ b/fluent-plugin-aws-elasticsearch-service.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "test-unit", "~> 3.0"
-  spec.add_runtime_dependency "fluentd", "~> 0"
+  spec.add_runtime_dependency "fluentd", "~> 0", "~> 1"
   spec.add_runtime_dependency "fluent-plugin-elasticsearch", "~> 2.4.0"
   spec.add_runtime_dependency "aws-sdk", "~> 3"
   spec.add_runtime_dependency "faraday_middleware-aws-sigv4", ">= 0.2.4", "< 0.3.0"

--- a/fluent-plugin-aws-elasticsearch-service.gemspec
+++ b/fluent-plugin-aws-elasticsearch-service.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-aws-elasticsearch-service"
-  spec.version       = "1.1.0"
+  spec.version       = "1.2.0"
   spec.authors       = ["atomita"]
   spec.email         = ["sleeping.cait.sith+gh@gmail.com"]
 

--- a/fluent-plugin-aws-elasticsearch-service.gemspec
+++ b/fluent-plugin-aws-elasticsearch-service.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "test-unit", "~> 3.0"
-  spec.add_runtime_dependency "fluentd"
+  spec.add_runtime_dependency "fluentd", ">= 0.14"
   spec.add_runtime_dependency "fluent-plugin-elasticsearch", "~> 2.4.0"
   spec.add_runtime_dependency "aws-sdk", "~> 3"
   spec.add_runtime_dependency "faraday_middleware-aws-sigv4", ">= 0.2.4", "< 0.3.0"

--- a/fluent-plugin-aws-elasticsearch-service.gemspec
+++ b/fluent-plugin-aws-elasticsearch-service.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "test-unit", "~> 3.0"
-  spec.add_runtime_dependency "fluentd", "~> 0", "~> 1"
+  spec.add_runtime_dependency "fluentd", "< 2"
   spec.add_runtime_dependency "fluent-plugin-elasticsearch", "~> 2.4.0"
   spec.add_runtime_dependency "aws-sdk", "~> 3"
   spec.add_runtime_dependency "faraday_middleware-aws-sigv4", ">= 0.2.4", "< 0.3.0"


### PR DESCRIPTION
We use fluentd 1.2, but installations fail because the dependency for this gem requires fluent `~> 0`. This simply adds `~> 1` for support of newer versions