### PR TITLE
Slow Gem Install Fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'fluent-plugin-elasticsearch', "~> 2.4.0", require: false
-gem 'aws-sdk', '~> 3', require: false
+gem 'aws-sdk-core', '~> 3', require: false
 gem 'faraday_middleware-aws-sigv4', '>= 0.2.4', '< 0.3.0', require: false

--- a/fluent-plugin-aws-elasticsearch-service.gemspec
+++ b/fluent-plugin-aws-elasticsearch-service.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "test-unit", "~> 3.0"
   spec.add_runtime_dependency "fluentd", "~> 0"
   spec.add_runtime_dependency "fluent-plugin-elasticsearch", "~> 2.4.0"
-  spec.add_runtime_dependency "aws-sdk", "~> 3"
+  spec.add_runtime_dependency "aws-sdk-core", "~> 3"
   spec.add_runtime_dependency "faraday_middleware-aws-sigv4", ">= 0.2.4", "< 0.3.0"
 end

--- a/lib/fluent/plugin/out_aws-elasticsearch-service.rb
+++ b/lib/fluent/plugin/out_aws-elasticsearch-service.rb
@@ -2,7 +2,7 @@
 
 require 'rubygems'
 require 'fluent/plugin/out_elasticsearch'
-require 'aws-sdk'
+require 'aws-sdk-core'
 require 'faraday_middleware/aws_sigv4'
 
 


### PR DESCRIPTION
Reduced aws-sdk Dependencies to only aws-sdk-core

Built gem via (you may want to bump the local version in the .gemspec first):
```
gem build fluent-plugin-aws-elasticsearch-service.gemspec
```

And confirmed new gem installs quickly and works as expected

closes https://github.com/atomita/fluent-plugin-aws-elasticsearch-service/issues/48

Edit: To do the `gem build` above, you must have the project checked out via git, because the gemspec is using a `git` command to find the files to bundle, otherwise, you'll get an empty gem:
https://github.com/atomita/fluent-plugin-aws-elasticsearch-service/blob/master/fluent-plugin-aws-elasticsearch-service.gemspec#L18