### PR TITLE
Permit to work with Fluentd v1 and ES plugin v3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in fluent-plugin-aws-elasticsearch-service.gemspec
 gemspec
 
-gem 'fluent-plugin-elasticsearch', "~> 2.4.0", require: false
+gem 'fluent-plugin-elasticsearch', [">= 2.4.0", "< 4"], require: false
 gem 'aws-sdk-core', '~> 3', require: false
 gem 'faraday_middleware-aws-sigv4', '>= 0.2.4', '< 0.3.0', require: false

--- a/fluent-plugin-aws-elasticsearch-service.gemspec
+++ b/fluent-plugin-aws-elasticsearch-service.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "test-unit", "~> 3.0"
-  spec.add_runtime_dependency "fluentd", "~> 0"
-  spec.add_runtime_dependency "fluent-plugin-elasticsearch", "~> 2.4.0"
+  spec.add_runtime_dependency "fluentd", [">= 0.14.15", "< 2"]
+  spec.add_runtime_dependency "fluent-plugin-elasticsearch", [">= 2.4.0", "< 4"]
   spec.add_runtime_dependency "aws-sdk-core", "~> 3"
   spec.add_runtime_dependency "faraday_middleware-aws-sigv4", ">= 0.2.4", "< 0.3.0"
 end


### PR DESCRIPTION
Closes https://github.com/atomita/fluent-plugin-aws-elasticsearch-service/pull/46.

We should permit to work with ES plugin v3 and Fluentd v1.