### PR TITLE
Depends on fluent-plugin-elasticsearch v3.3.0 or later

### DIFF
--- a/fluent-plugin-aws-elasticsearch-service.gemspec
+++ b/fluent-plugin-aws-elasticsearch-service.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "test-unit", "~> 3.0"
   spec.add_runtime_dependency "fluentd", [">= 0.14.15", "< 2"]
-  spec.add_runtime_dependency "fluent-plugin-elasticsearch", [">= 2.4.0", "< 3.3.0"]
+  spec.add_runtime_dependency "fluent-plugin-elasticsearch", [">= 3.3.0", "< 4"]
   spec.add_runtime_dependency "aws-sdk-core", "~> 3"
   spec.add_runtime_dependency "faraday_middleware-aws-sigv4", ">= 0.2.4", "< 0.3.0"
 end

--- a/lib/fluent/plugin/out_aws-elasticsearch-service.rb
+++ b/lib/fluent/plugin/out_aws-elasticsearch-service.rb
@@ -31,7 +31,7 @@ module Fluent::Plugin
     #
     # @override
     #
-    def get_connection_options
+    def get_connection_options(con_host=nil)
       raise "`endpoint` require." if @endpoint.empty?
 
       hosts =


### PR DESCRIPTION
Because #get_connection_options's arity is changed to 1 from 0.
This is a breaking changes for this plugin.

Closes #52.

---

This PR contains breaking chnages.
Please merge this PR after v2.0.1 is released. (#53)