### PR TITLE
mask aws_secret_access_key in config

### DIFF
--- a/lib/fluent/plugin/out_aws-elasticsearch-service.rb
+++ b/lib/fluent/plugin/out_aws-elasticsearch-service.rb
@@ -15,7 +15,7 @@ module Fluent::Plugin
       config_param :region, :string
       config_param :url, :string
       config_param :access_key_id, :string, :default => ""
-      config_param :secret_access_key, :string, :default => ""
+      config_param :secret_access_key, :string, :default => "", secret: true
       config_param :assume_role_arn, :string, :default => nil
       config_param :ecs_container_credentials_relative_uri, :string, :default => nil #Set with AWS_CONTAINER_CREDENTIALS_RELATIVE_URI environment variable value
       config_param :assume_role_session_name, :string, :default => "fluentd"


### PR DESCRIPTION
so that it doesn't get printed out by fluentd on startup.