### PR TITLE
Move faraday_middleware-aws-sigv4 to major v0.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,4 @@ gemspec
 
 gem 'fluent-plugin-elasticsearch', [">= 2.4.0", "< 4"], require: false
 gem 'aws-sdk-core', '~> 3', require: false
-gem 'faraday_middleware-aws-sigv4', '>= 0.2.4', '< 0.3.0', require: false
+gem 'faraday_middleware-aws-sigv4', '~> 0.3.0', require: false


### PR DESCRIPTION
This is working fine with v0.3.0. Without it, the dependency chain is broken and requires a manual fix on each install.

I think this is what is happening:
fluent-plugin-aws-elasticsearch-service -> fluent-plugin-elasticsearch -> elasticsearch-transport -> elasticsearch-transport (requres faraday (>= 0)) -> faraday (some version higher than 0.15)

Then the faraday_middleware-aws-sigv4 version installed by this project (>= 0.2.4, < 0.3.0) is expecting a faraday below v0.15 resulting in the error in this issue: #59 

For every image I'm using this project in, I'm having to run a manual update
`gem update faraday_middleware-aws-sigv4`

The only difference between faraday_middleware-aws-sigv4 v0.2.5 and v0.3.0 is [added support for faraday >= 0.15](https://github.com/winebarrel/faraday_middleware-aws-sigv4/commit/2904e1d4b7ede9328e4278e1ea3189dd0432468b). So, there are no compatibility issues.