### PR TITLE
Add config for sts_credentials_region

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Additionally, you can use an STS assumed role as the authenticating factor and i
     region eu-west-1
     assume_role_arn arn:aws:sts::ACCOUNT:role/ROLE
     assume_role_session_name SESSION_ID # Defaults to fluentd if omitted
+    sts_credentials_region us-west-2 # Defaults to region if omitted
   </endpoint>
 ```
 

--- a/lib/fluent/plugin/out_aws-elasticsearch-service.rb
+++ b/lib/fluent/plugin/out_aws-elasticsearch-service.rb
@@ -20,6 +20,7 @@ module Fluent::Plugin
       config_param :ecs_container_credentials_relative_uri, :string, :default => nil #Set with AWS_CONTAINER_CREDENTIALS_RELATIVE_URI environment variable value
       config_param :assume_role_session_name, :string, :default => "fluentd"
       config_param :assume_role_web_identity_token_file, :string, :default => nil
+      config_param :sts_credentials_region, :string, :default => ""
     end
 
     # here overrides default value of reload_connections to false because
@@ -86,17 +87,22 @@ module Fluent::Plugin
               }).credentials
             end
           else
+            sts_credentials_region = opts[:sts_credentials_region]
+            if sts_credentials_region.empty?
+              sts_credentials_region = opts[:region]
+            end
+
             if opts[:assume_role_web_identity_token_file].nil?
               credentials = sts_credential_provider({
                               role_arn: opts[:assume_role_arn],
                               role_session_name: opts[:assume_role_session_name],
-                              region: opts[:region]
+                              region: sts_credentials_region
                             }).credentials
             else
               credentials = sts_web_identity_credential_provider({
                               role_arn: opts[:assume_role_arn],
                               web_identity_token_file: opts[:assume_role_web_identity_token_file],
-                              region: opts[:region]
+                              region: sts_credentials_region
                             }).credentials
             end
           end

--- a/lib/fluent/plugin/out_aws-elasticsearch-service.rb
+++ b/lib/fluent/plugin/out_aws-elasticsearch-service.rb
@@ -117,8 +117,6 @@ module Fluent::Plugin
       opts[:sts_credentials_region] || opts[:region]
     end
 
-
-
     def sts_credential_provider(opts)
       # AssumeRoleCredentials is an auto-refreshing credential provider
       @sts ||= Aws::AssumeRoleCredentials.new(opts)


### PR DESCRIPTION
This is useful for fluentd deployments running in a different region
than their elasticsearch cluster and want to take advantage of local sts
endpoints