### PR TITLE
Allow fluent-plugin-elasticsearch version 5

### DIFF
--- a/fluent-plugin-aws-elasticsearch-service.gemspec
+++ b/fluent-plugin-aws-elasticsearch-service.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "test-unit", "~> 3.0"
   spec.add_runtime_dependency "fluentd", [">= 0.14.15", "< 2"]
-  spec.add_runtime_dependency "fluent-plugin-elasticsearch", [">= 3.3.0", "< 5"]
+  spec.add_runtime_dependency "fluent-plugin-elasticsearch", [">= 3.3.0", "< 6"]
   spec.add_runtime_dependency "aws-sdk-core", "~> 3"
   spec.add_runtime_dependency "faraday_middleware-aws-sigv4", "~> 0.3.0"
 end


### PR DESCRIPTION
We need some feature from fluent-plugin-elasticsearch version 5.0.2.  Thanks!