### PR TITLE
Workaround to use with elasticsearch gem 7.14 or later

### DIFF
--- a/lib/fluent/plugin/out_aws-elasticsearch-service.rb
+++ b/lib/fluent/plugin/out_aws-elasticsearch-service.rb
@@ -140,10 +140,7 @@ module Fluent::Plugin
   class ElasticsearchOutput
     module Elasticsearch
 
-      module Client
-        include ::Elasticsearch::Client
-        extend self
-      end
+      class Client < ::Elasticsearch::Client; end
 
       module Transport
         module Transport

--- a/lib/fluent/plugin/out_aws-elasticsearch-service.rb
+++ b/lib/fluent/plugin/out_aws-elasticsearch-service.rb
@@ -140,7 +140,11 @@ module Fluent::Plugin
   class ElasticsearchOutput
     module Elasticsearch
 
-      class Client < ::Elasticsearch::Client; end
+      class Client < ::Elasticsearch::Client
+        def verify_with_version_or_header(body, version, headers)
+          @verified = true
+        end
+      end
 
       module Transport
         module Transport


### PR DESCRIPTION
Because of the change of the elasticsearch gem (https://github.com/elastic/elasticsearch-ruby/pull/1360), AWS OpenSearch has not been supported.
Maybe relates to
- https://github.com/atomita/fluent-plugin-aws-elasticsearch-service/issues/72 
- https://github.com/atomita/fluent-plugin-aws-elasticsearch-service/issues/74

I think we need some workaround.

My suggestion is based on [this comment](https://github.com/elastic/elasticsearch-ruby/issues/1429#issuecomment-958162468).
This method will allow any versions and any distributions of elasticsearch.
I confirmed that I could transfer messages to AWS OpenSearch Service.


I'm a beginner and I can't think of a better way...
If there is a better way, I would love to hear advices.

